### PR TITLE
feat: git (scan only changed files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ sls --dir <directory> --exclude <folders> --commits <100>
 - **`--exclude <folders>`**: Comma-separated list of folders to exclude from scanning.
 - **`--commits <number>`**: Number of most recent commits to scan (defaults to 100 most recent commits).
 
+---
+
 ### Scan Only Changed Files
 
 To scan only files and lines that have been changed in recent commits (useful in CI pipelines to only scan code changes):

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **Customizable Rules**: Supports regex patterns for popular companies and services like AWS, Azure, Stripe, PayPal, and many more.
 - **Exclusion Options**: Allows users to exclude specific folders and file extensions from scanning.
 - **Parallel Processing**: Efficiently scans large repositories using parallel processing to streamline file scanning.
+- **Selective Scanning**: Scan only files that have changed in recent commits, optimizing CI/CD pipeline usage.
 
 ## Install
 
@@ -38,19 +39,32 @@ sls --dir <directory>
 
 > Note: Secure Log Scan automatically defaults to `$cwd` if `--dir` flag is not provided
 
-### Excluding folders and extensions
+### Excluding folders and specifying maximum git commits
 
 You can exclude specific folders or file extensions using the `--exclude` option:
 
 ---
 
 ```bash
-sls --dir <directory> --exclude <folders>
+sls --dir <directory> --exclude <folders> --commits <100>
 ```
 
 ---
 
 - **`--exclude <folders>`**: Comma-separated list of folders to exclude from scanning.
+- **`--commits <number>`**: Number of most recent commits to scan (defaults to 100 most recent commits).
+
+### Scan Only Changed Files
+
+To scan only files and lines that have been changed in recent commits (useful in CI pipelines to only scan code changes):
+
+---
+
+```bash
+sls --changed
+```
+
+---
 
 ### Config file
 

--- a/lib/gitScanner.js
+++ b/lib/gitScanner.js
@@ -1,14 +1,136 @@
-const { exec } = require("child_process");
+const { exec, execSync } = require("child_process");
 const readline = require("readline");
 const path = require("path");
 const chalk = require("chalk");
+const fs = require("fs");
+
+// Function to scan a specific line for secrets
+const scanLineForSecrets = (
+  line,
+  lineNumber,
+  filePath,
+  commitHash,
+  authorName,
+  authorEmail,
+  commitTitle,
+  regexPatterns
+) => {
+  for (const [company, regex] of Object.entries(regexPatterns)) {
+    if (regex.test(line)) {
+      console.log(
+        chalk.greenBright.bold(`\nPotential secret detected in git commit:`)
+      );
+      console.log(`${chalk.bold("Detector:")} ${company}`);
+      console.log(`${chalk.bold("File:")} ${filePath}`);
+      console.log(`${chalk.bold("Line:")} ${lineNumber}`);
+      console.log(`${chalk.bold("Matched Value:")} ${line.trim()}`);
+      console.log(`${chalk.bold("Commit Hash:")} ${commitHash}`);
+      console.log(`${chalk.bold("Author:")} ${authorName} <${authorEmail}>`);
+      console.log(`${chalk.bold("Commit Title:")} ${commitTitle}\n`);
+      break;
+    }
+  }
+};
+
+// Function to get changed lines from the latest commits
+const getChangedLinesWithDetails = (repoPath) => {
+  const changedLines = {};
+
+  try {
+    // Get all changes in the branch since the last commit that is shared with the main branch
+    const gitCommand = `git log -p --first-parent --format="%H|%an|%ae|%s" origin/main..HEAD`;
+    const result = execSync(gitCommand, { cwd: repoPath });
+    const logOutput = result.toString().split("\n");
+
+    let currentFile = null;
+    let commitInfo = null;
+    let lineOffset = 0;
+
+    logOutput.forEach((line) => {
+      if (line.includes("|")) {
+        // Extract commit info
+        const [commitHash, authorName, authorEmail, commitTitle] =
+          line.split("|");
+        commitInfo = { commitHash, authorName, authorEmail, commitTitle };
+      } else if (line.startsWith("diff --git")) {
+        // Extract file path
+        const fileMatch = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+        if (fileMatch) {
+          currentFile = fileMatch[2]; // Get the path after 'b/'
+        }
+      } else if (line.startsWith("@@")) {
+        // Extract line number from the hunk header
+        const lineMatch = /^@@ -\d+,\d+ \+(\d+),\d+ @@/.exec(line);
+        if (lineMatch && currentFile && commitInfo) {
+          const startLine = parseInt(lineMatch[1], 10);
+          lineOffset = startLine;
+          if (!changedLines[currentFile]) {
+            changedLines[currentFile] = [];
+          }
+        }
+      } else if (line.startsWith("+") && !line.startsWith("+++")) {
+        // Detect added lines only
+        if (currentFile && commitInfo) {
+          const addedLine = line.slice(1); // Remove leading '+' character
+          changedLines[currentFile].push({
+            line: addedLine,
+            lineNumber: lineOffset,
+            ...commitInfo,
+          });
+          lineOffset++;
+        }
+      }
+    });
+  } catch (error) {
+    console.error("Error getting changed lines:", error.message);
+  }
+
+  return changedLines;
+};
+
+// Scan only the changed lines in each file
+const scanChangedLinesInFiles = (changedFiles, repoPath, regexPatterns) => {
+  Object.entries(changedFiles).forEach(([filePath, lines]) => {
+    const fullPath = path.join(repoPath, filePath);
+    if (fs.existsSync(fullPath)) {
+      lines.forEach(
+        ({
+          line,
+          lineNumber,
+          commitHash,
+          authorName,
+          authorEmail,
+          commitTitle,
+        }) => {
+          scanLineForSecrets(
+            line,
+            lineNumber,
+            filePath,
+            commitHash,
+            authorName,
+            authorEmail,
+            commitTitle,
+            regexPatterns
+          );
+        }
+      );
+    }
+  });
+};
 
 // Function to scan Git commits for secrets
 const scanGitCommitsForSecrets = async (
   repoPath,
   limit = 100,
-  regexPatterns
+  regexPatterns,
+  onlyChangedFiles
 ) => {
+  if (onlyChangedFiles) {
+    const changedFiles = getChangedLinesWithDetails(repoPath);
+    scanChangedLinesInFiles(changedFiles, repoPath, regexPatterns);
+    return;
+  }
+
   return new Promise((resolve, reject) => {
     // Git command to get commit details, including author, diff, and title
     const gitCommand = `git log -p --max-count=${limit} --pretty=format:"commit %H|%an|%ae|%s"`;
@@ -49,33 +171,16 @@ const scanGitCommitsForSecrets = async (
             const trimmedLine = line.slice(1).trim(); // Remove the leading '+' and trim
 
             if (currentCommit.filePath) {
-              for (const [company, regex] of Object.entries(regexPatterns)) {
-                if (regex.test(trimmedLine)) {
-                  console.log(
-                    chalk.greenBright.bold(
-                      `\nPotential secret detected in git commit:`
-                    )
-                  );
-                  console.log(`${chalk.bold("Detector:")} ${company}`);
-                  console.log(
-                    `${chalk.bold("File:")} ${currentCommit.filePath}`
-                  );
-                  console.log(`${chalk.bold("Line:")} ${trimmedLine}`);
-                  console.log(`${chalk.bold("Matched Value:")} ${trimmedLine}`);
-                  console.log(
-                    `${chalk.bold("Commit Hash:")} ${currentCommit.hash}`
-                  );
-                  console.log(
-                    `${chalk.bold("Author:")} ${currentCommit.authorName} <${
-                      currentCommit.authorEmail
-                    }>`
-                  );
-                  console.log(
-                    `${chalk.bold("Commit Title:")} ${currentCommit.title}\n`
-                  );
-                  break;
-                }
-              }
+              scanLineForSecrets(
+                trimmedLine,
+                trimmedLine,
+                currentCommit.filePath,
+                currentCommit.hash,
+                currentCommit.authorName,
+                currentCommit.authorEmail,
+                currentCommit.title,
+                regexPatterns
+              );
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "securelog-scan",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A CLI tool to scan codebases for potential secrets.",
   "main": "bin/sls.js",
   "author": {


### PR DESCRIPTION
- Feat only scan files that was changed (and yet to be merged) when `--changed` file is passed
- Updated readme to include `--commit` flag for users to specify maximum most recent commits to scan (this doesn't do anything when `--changed` is passed is that's supposed to scan only changed files for secrets